### PR TITLE
Adding further fields to swagger and info objects

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -178,6 +178,8 @@ class OutputView(MethodView):
             "info": {
                 "version": self.spec.get('version', "0.0.0"),
                 "title": self.spec.get('title', "A swagger API"),
+                "description": self.spec.get('description', "API description"),
+                "termsOfService": self.spec.get('termsOfService', "Terms of service"),
             },
             "paths": defaultdict(dict),
             "definitions": defaultdict(dict)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -181,6 +181,8 @@ class OutputView(MethodView):
                 "description": self.spec.get('description', "API description"),
                 "termsOfService": self.spec.get('termsOfService', "Terms of service"),
             },
+            "host": self.config.get('host', "hostname"),
+            "basePath": self.config.get('basePath', "/"),
             "paths": defaultdict(dict),
             "definitions": defaultdict(dict)
         }


### PR DESCRIPTION
Adding the rest of the string fields for the info object. Contact and license fields still missing.

Check all the possible fields [here](http://swagger.io/specification/#infoObject).