### PR TITLE
func_globals -> __globals__ in order to support python 3.+

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -17,7 +17,7 @@ def swag_from(filepath, filetype=None):
         # function.__code__.co_filename # option to access filename
         if not filepath.startswith('/'):
             final_filepath = os.path.join(
-                os.path.dirname(function.func_globals['__file__']), filepath
+                os.path.dirname(function.__globals__['__file__']), filepath
             )
         else:
             final_filepath = filepath


### PR DESCRIPTION
This is fix of an error:
```python
    @swag_from('username_definitions.yml')
  File "/Users/lorekhov/.virtualenvs/restodoc/lib/python3.4/site-packages/flasgger/utils.py", line 20, in decorator
    os.path.dirname(function.func_globals['__file__']), filepath
AttributeError: 'function' object has no attribute 'func_globals'
```

From python 2.6 and up you can access function globals as ```__globals__```. 
So, if you merge this pull request, you drop python 2.5 support in favor of python 3.x.
But who cares about python2.5? :)