### PR TITLE
Update base.py to allow securityDefinitions

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -216,8 +216,9 @@ class OutputView(MethodView):
         if self.config.get("basePath"):
             data["basePath"] = self.config.get('basePath')
         if self.config.get("securityDefinitions"):
-            data["securityDefinitions"] = self.config.get('securityDefinitions')
-
+            data["securityDefinitions"] = self.config.get(
+                'securityDefinitions'
+            )
         # set defaults from template
         if self.template is not None:
             data.update(self.template)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -215,6 +215,8 @@ class OutputView(MethodView):
             data['host'] = self.config.get('host')
         if self.config.get("basePath"):
             data["basePath"] = self.config.get('basePath')
+        if self.config.get("securityDefinitions"):
+            data["securityDefinitions"] = self.config.get('securityDefinitions')
 
         # set defaults from template
         if self.template is not None:


### PR DESCRIPTION
Currently there's no way to specify the securityDefinitions.
This is a super simple change to allow add it on app initializacion.

```python
app.config['SWAGGER'] = {
    "swagger_version": "2.0",
    "basePath": "/v1",
    "securityDefinitions": {
        "petstore_auth": {
            "type": "oauth2",
            "authorizationUrl": "/oauth/dialog",
            "flow": "implicit",
            "scopes": {
                "write:pets": "modify pets in your account",
                "read:pets": "read your pets"
            }
        },
        "api_key": {
            "type": "apiKey",
            "name": "api_key",
            "in": "header"
        }
    }
```