### PR TITLE
remove default cors headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ app = Flask(__name__)
 
 app.config['SWAGGER'] = {
     "swagger_version": "2.0",
-    # headers are optional, the following are default
+    # headers are optional, and default to an empty array. If specified, they overwrites the headers with the same key in your flask app.
     # "headers": [
     #     ('Access-Control-Allow-Origin', '*'),
     #     ('Access-Control-Allow-Headers', "Authorization, Content-Type"),
@@ -306,7 +306,7 @@ app.config['SWAGGER'] = {
     #     ('Access-Control-Allow-Credentials', "true"),
     #     ('Access-Control-Max-Age', 60 * 60 * 24 * 20),
     # ],
-    # another optional settings
+    # other optional settings
     # "url_prefix": "swaggerdocs",
     # "subdomain": "docs.mysite,com",
     # specs are also optional if not set /spec is registered exposing all views

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -300,13 +300,6 @@ class Swagger(object):
 
     DEFAULT_CONFIG = {
         "headers": [
-            ('Access-Control-Allow-Origin', '*'),
-            ('Access-Control-Allow-Headers', "Authorization, Content-Type"),
-            ('Access-Control-Expose-Headers', "Authorization"),
-            ('Access-Control-Allow-Methods',
-             "GET, POST, PUT, DELETE, OPTIONS"),
-            ('Access-Control-Allow-Credentials', "true"),
-            ('Access-Control-Max-Age', 60 * 60 * 24 * 20),
         ],
         "specs": [
             {
@@ -378,5 +371,5 @@ class Swagger(object):
         @app.after_request
         def after_request(response):  # noqa
             for header, value in self.config.get('headers'):
-                response.headers.add(header, value)
+                response.headers[header] = value
             return response

--- a/flasgger/example_app.py
+++ b/flasgger/example_app.py
@@ -15,19 +15,11 @@ app = Flask(__name__)
 app.config['SWAGGER'] = {
     "swagger_version": "2.0",
     "title": "Flasgger",
-    # headers are optional, the following are default
-    # "headers": [
-    #     ('Access-Control-Allow-Origin', '*'),
-    #     ('Access-Control-Allow-Headers', "Authorization, Content-Type"),
-    #     ('Access-Control-Expose-Headers', "Authorization"),
-    #     ('Access-Control-Allow-Methods', "GET, POST, PUT, DELETE, OPTIONS"),
-    #     ('Access-Control-Allow-Credentials', "true"),
-    #     ('Access-Control-Max-Age', 60 * 60 * 24 * 20),
-    # ],
-    # another optional settings
-    # "url_prefix": "swaggerdocs",
-    # "subdomain": "docs.mysite,com",
-    # specs are also optional if not set /spec is registered exposing all views
+    "headers": [
+        ('Access-Control-Allow-Origin', '*'),
+        ('Access-Control-Allow-Methods', "GET, POST, PUT, DELETE, OPTIONS"),
+        ('Access-Control-Allow-Credentials', "true"),
+    ],
     "specs": [
         {
             "version": "0.0.1",
@@ -55,6 +47,13 @@ app.config['SWAGGER'] = {
 }
 
 swagger = Swagger(app)  # you can pass config here Swagger(config={})
+
+@app.after_request
+def allow_origin(response):
+    response.headers['Access-Control-Allow-Origin'] = 'http://example.com'
+    response.headers['Access-Control-Allow-Credentials'] = 'true'
+
+    return response
 
 
 class UserAPI(MethodView):


### PR DESCRIPTION
Also make the config headers overwrite the existing headers. 

The reason for this PR is that if there's already `Access-Control-Allow-Origin` response header set in the flask app through `@app.after_request`, the default cors headers will be appended which makes the response headers invalid. See the code change I made in example_app.py. Without changes in base.py the resulting headers are:

```
$ curl -I 'http://localhost:5000/' 
HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 546
Access-Control-Allow-Origin: http://example.com
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Access-Control-Allow-Credentials: true
Server: Werkzeug/0.11.10 Python/2.7.10
Date: Wed, 27 Jul 2016 07:37:08 GMT
```

After the change the headers are:

```
$ curl -I 'http://localhost:5000/' 
HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 546
Access-Control-Allow-Origin: *
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
Server: Werkzeug/0.11.10 Python/2.7.10
Date: Wed, 27 Jul 2016 07:38:00 GMT
```