### PR TITLE
Fixed docstring check for Flask-RESTful

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -255,8 +255,8 @@ class OutputView(MethodView):
             operations = dict()
             for verb, method in methods.items():
                 klass = method.__dict__.get('view_class', None)
-                if klass and hasattr(klass, 'dispatch_request'):
-                    method = klass.__dict__.get('dispatch_request')
+                if klass and hasattr(klass, 'verb'):
+                    method = klass.__dict__.get('verb')
                 summary, description, swag = _parse_docstring(
                     method, self.process_doc, endpoint=rule.endpoint, verb=verb
                 )

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -257,6 +257,8 @@ class OutputView(MethodView):
                 klass = method.__dict__.get('view_class', None)
                 if klass and hasattr(klass, 'verb'):
                     method = klass.__dict__.get('verb')
+                elif klass and hasattr(klass, 'dispatch_request'):
+                    method = klass.__dict__.get('dispatch_request')
                 summary, description, swag = _parse_docstring(
                     method, self.process_doc, endpoint=rule.endpoint, verb=verb
                 )


### PR DESCRIPTION
Using Flask-RESTful 0.3.5, no specs were extracted from the docstrings in my views. After making this change, the /spec endpoint was populated from the docstrings. It also seems to work for regular Flask view routes. 

I could not find any rigorous tests to run, so I hope you can give me some feedback. This is my first pull request, so I apologise if my issue seems unclear. Please let me know if you need more info.
