### PR TITLE
Minimal fix for docstring check for Flask-RESTful.

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -179,10 +179,11 @@ class SpecsView(MethodView):
         )
 
 
-def is_valid_dispatch_view(endpoint):
+def has_valid_dispatch_view_docs(endpoint):
     klass = endpoint.__dict__.get('view_class', None)
     return klass and hasattr(klass, 'dispatch_request') \
-        and hasattr(endpoint, 'methods')
+        and hasattr(endpoint, 'methods') \
+        and getattr(klass, 'dispatch_request').__doc__
 
 
 class OutputView(MethodView):
@@ -243,7 +244,7 @@ class OutputView(MethodView):
             endpoint = current_app.view_functions[rule.endpoint]
             methods = dict()
             for verb in rule.methods.difference(ignore_verbs):
-                if is_valid_dispatch_view(endpoint):
+                if has_valid_dispatch_view_docs(endpoint):
                     endpoint.methods = endpoint.methods or ['GET']
                     if verb in endpoint.methods:
                         methods[verb.lower()] = endpoint


### PR DESCRIPTION
Simpler fix.



The idea is that if the class has a dispatch_request method and it is documented then it will use its documentation. Otherwise it will fallback to using the class method $verb's documentation.

I think that was the intent of the original author anyway. It's better to prefer the dispatch_request docs only if there are any - but fallback to the verb's docs otherwise.

Previously it just checked whether dispatch_request existed and if so, it only checked the class for docs directly, not the verb method.
