### PR TITLE
Added six to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask>=0.10
 PyYAML>=3.0
 jsonschema>=2.5.1
+six>=1.10.0
 mistune
 
 # dev


### PR DESCRIPTION
Had trouble building from master and it turns out `six` was missing from the `requirements.txt` file. Not sure exactly what version is _needed_, as it's only `string_types` that is used, but had no trouble using `1.10.0` (current version) myself.