### PR TITLE
First stab at testing all the examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - 3.6
+
+before_install:
+  - pip install -r requirements.txt
+
+script:
+  - py.test -s -vv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 install:
-	python setup.py develop
+	@python setup.py develop
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-.PHONY: run
-run:
-	python wsgi.py
-
 .PHONY: install
 install:
 	python setup.py develop

--- a/examples/base_model_view.py
+++ b/examples/base_model_view.py
@@ -68,5 +68,5 @@ app.add_url_rule(
     methods=['GET']
 )
 
-
-app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -68,6 +68,5 @@ def colors(palette):
 
     return jsonify(result)
 
-
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/colors_from_specdict.py
+++ b/examples/colors_from_specdict.py
@@ -110,6 +110,5 @@ def colors(palette):
 
     return jsonify(result)
 
-
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/colors_with_schema.py
+++ b/examples/colors_with_schema.py
@@ -56,4 +56,5 @@ app.add_url_rule(
     methods=['GET']
 )
 
-app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/definition_object_test.py
+++ b/examples/definition_object_test.py
@@ -114,4 +114,6 @@ class Foo(View):
 
 
 app.add_url_rule('/dispatch_request', view_func=Foo.as_view('foo'))
-app.run(debug=True)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -409,6 +409,5 @@ def hello():
     </p>
     """
 
-
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/example_blueprint.py
+++ b/examples/example_blueprint.py
@@ -52,3 +52,6 @@ swag = Swagger(app)
 
 if __name__ == "__main__":
     app.run(debug=True)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/marshmallow_apispec.py
+++ b/examples/marshmallow_apispec.py
@@ -70,5 +70,5 @@ app.add_url_rule(
     methods=['POST']
 )
 
-
-app.run(debug=True)
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ apispec
 flask-restful
 pep8==1.5.7
 flake8==2.4.1
+pytest
+flex
 
 # install flasgger itself as editable
 -e .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import os
+from importlib import import_module
+
+import pytest
+
+
+EXAMPLES_DIR = "examples/"
+
+
+def remove_suffix(fpath):
+    """Remove all file ending suffixes"""
+    return os.path.splitext(fpath)[0]
+
+
+def is_python_file(fpath):
+    """Naive Python module filterer"""
+    return ".py" in fpath and "__" not in fpath
+
+
+def pathify(basenames):
+    """*nix to python module path"""
+    example = EXAMPLES_DIR.replace("/", ".")
+    return [example + basename for basename in basenames]
+
+
+@pytest.fixture
+def examples():
+    """All example modules"""
+    all_files = os.listdir(EXAMPLES_DIR)
+    python_files = [f for f in all_files if is_python_file(f)]
+    basenames = [remove_suffix(f) for f in python_files]
+    return [import_module(module) for module in pathify(basenames)]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,19 @@
+import json
+
+from flex.core import validate
+
+# allow for different spec routes in examples
+spec_urls = [
+    "/apispec_1.json",
+    "/v1/spec",
+]
+
+
+def test_validate_example_specs(examples):
+    for example in examples:
+        app = example.app.test_client()
+        responses = [app.get(url) for url in spec_urls]
+        response = next(filter(lambda r: r.status_code == 200, responses))
+        decoded = response.data.decode("utf-8")
+        spec = json.loads(decoded)
+        validate(spec)


### PR DESCRIPTION
So, here's the big picture of what I was trying to do:

- [x] Remove all `app.run(debug=True)` from the examples (for importing later)
- [x] Programmatically import all example modules in `conftest.py` fixture
- [x] Import every app from every module and request the swagger spec and validate

The final step failed because the examples don't work :) Hence, we are getting somewhere. 

~~You'd have to enable the Travis build since you are the admin of the project.~~ Already up, nice!

Code is kinda messy as I hacked it together, but this could give you an idea. Feel free to remix/remove anything that you don't want. No ego here :)

I've enabled Tox and Travis (via the configuration files (.travis.yml and tox.ini) which can automate tedious testing of python projects).

I think we can use http://flex-swagger.readthedocs.io/en/latest/ for validation?

Follows from https://github.com/rochacbruno/flasgger/issues/64#issuecomment-289791411.