### PR TITLE
Use a UI grid to show examples in the demo app

### DIFF
--- a/demo_app/templates/flasgger.html
+++ b/demo_app/templates/flasgger.html
@@ -1,9 +1,9 @@
-
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Flasgger - Demo apps</title>
   <link rel="icon" type="image/png" href="/colors/flasgger_static/images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="/colors/flasgger_static/images/favicon-16x16.png" sizes="16x16" />
@@ -12,6 +12,69 @@
   <link href='/colors/flasgger_static/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='/colors/flasgger_static/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='/colors/flasgger_static/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='{{ url_for('static', filename='styles.css') }}' rel="styleshet" type='text/css'/>
+  <style>
+    .swagger-section #header,
+    .swagger-section .swagger-ui-wrap {
+      min-width: auto;
+    }
+
+    #examples {
+      display: flex;
+      flex-wrap: wrap;
+      font-size: 1rem;
+      justify-content: space-between;
+      margin-top: 1rem;
+      padding: .5rem;
+    }
+
+    #examples h2 {
+      font-size: 1rem;
+      font-weight: bold;
+      word-wrap: break-word;
+    }
+
+    #examples li {
+      background-color: #efefef;
+      margin: .5rem 0 0 0;
+      overflow: hidden;
+      width: 100%;
+      padding: .5rem;
+    }
+
+    #examples ol,
+    #examples li li {
+      margin: .5rem 0 0 0;
+      padding: 0;
+      width: 100%;
+    }
+
+    #examples p {
+      line-height: 1.2;
+    }
+
+    #examples a {
+      word-wrap: break-word;
+    }
+
+    @media all and (min-width: 410px) {
+      #examples li {
+        width: calc(50% - 1.25rem);
+      }
+      #examples li li {
+        width: 100%;
+      }
+    }
+
+    @media all and (min-width: 760px) {
+      #examples li {
+        width: calc(33% - 1.25rem);
+      }
+      #examples li li {
+        width: 100%;
+      }
+    }
+  </style>
 
   <script src='/colors/flasgger_static/lib/object-assign-pollyfill.js' type='text/javascript'></script>
   <script src='/colors/flasgger_static/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
@@ -47,17 +110,15 @@
 </div>
 <div id="swagger-ui-container" class="swagger-ui-wrap">
 
-    <ul>
+    <ul id="examples">
     {% for example, mod in examples.items() %}
         <li>
+            <h2>{{example}}</h2>
+            <p>{{mod.__doc__}}</p>
             <ol>
-                <p>
-                    <h2>{{example}}</h2>
-                    {{mod.__doc__}}
-                </p>
                 <li>Live demo: <a href="{{example}}/apidocs">{{example}}</a></li>
                 <li>Json output: <a href="{{example}}/apidocs/?json=true">{{example}}/?json=true</a></li>
-                <li>Code: <a target="_blank" href="https://github.com/rochacbruno/flasgger/blob/master/examples/{{example}}.py">examples/{{example}}.py</a></li>
+                <li>Code: <a target="_blank" href="https://github.com/rochacbruno/flasgger/blob/master/examples/{{example}}.py">examples{{example}}.py</a></li>
             </ol>
         </li>
     {% endfor %}


### PR DESCRIPTION
As suggested in #81.

Small screens:

<img width="270" alt="screen shot 2017-04-02 at 00 33 57" src="https://cloud.githubusercontent.com/assets/4732915/24584213/7184d03e-173c-11e7-9dbb-3cc2bca60c16.png">

Medium screens:

<img width="270" alt="screen shot 2017-04-02 at 00 35 48" src="https://cloud.githubusercontent.com/assets/4732915/24584215/83db7fc6-173c-11e7-9752-dc9cd34c0cd1.png">

Large screens:

<img width="825" alt="screen shot 2017-04-02 at 00 39 00" src="https://cloud.githubusercontent.com/assets/4732915/24584229/cdb0cd90-173c-11e7-9b11-1b20b914bba6.png">

---

**Not directly related to the PR, but related to instructions in #81 (maybe bug?):**

I had to manually `pip install decorator flask_restful`, they are not listed in `demo_app/requirements.txt` (nor installed as dependencies) and I was getting `ModuleNotFoundError`.