### PR TITLE
operation: Make 'description' and 'summary' optional.

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -288,11 +288,11 @@ class APISpecsView(MethodView):
                             if def_id is not None:
                                 definitions[def_id].update(definition)
 
-                    operation = dict(
-                        summary=swag.get('summary'),
-                        description=swag.get('description'),
-                    )
-
+                    operation = {}
+                    if swag.get('summary'):
+                        operation['summary'] = swag.get('summary')
+                    if swag.get('description'):
+                        operation['description'] = swag.get('description')
                     if responses:
                         operation['responses'] = responses
                     # parameters - swagger ui dislikes empty parameter lists


### PR DESCRIPTION
Currently, if one does not specify a description on an operation, flasgger will emit

``` description: null ```

... which will make swagger-spec-validator-2.1.0 fail because that's not a string.

According to their validation the operation object has only one non-optional property: responses.

So I made 'description' and 'summary' optional.