### PR TITLE
Include yaml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyYAML>=3.0
 jsonschema>=2.5.1
 six>=1.10.0
 mistune
+yaml
 
 # optional (for dev)
 marshmallow


### PR DESCRIPTION
`yaml` module is imported in `flasgger.base` but it is not in the requirements.