### PR TITLE
Remove hardcoded specs_route from conftest

### DIFF
--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -67,8 +67,8 @@ template = apispec_to_template(
 
 """
 
-# start Flsgger using a template from apispec
-Swagger(app, template=template)
+# start Flasgger using a template from apispec
+swag = Swagger(app, template=template)
 
 
 if __name__ == '__main__':

--- a/examples/base_model_view.py
+++ b/examples/base_model_view.py
@@ -64,7 +64,7 @@ class PostAPIView(ModelAPIView):
 
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 app.add_url_rule(
     '/user/<team_id>',

--- a/examples/basic_auth.py
+++ b/examples/basic_auth.py
@@ -49,7 +49,7 @@ app.config["SWAGGER"] = {
     "title": "Swagger Basic Auth App",
     "uiversion": 2,
 }
-Swagger(app,
+swag = Swagger(app,
     decorators=[ requires_basic_auth ],
     template={
         "swagger": "2.0",

--- a/examples/colors_from_specdict.py
+++ b/examples/colors_from_specdict.py
@@ -11,7 +11,7 @@ app.config['SWAGGER'] = {
     'title': 'Colors API',
     'uiversion': 2
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 colors_spec = {

--- a/examples/colors_template_json.py
+++ b/examples/colors_template_json.py
@@ -10,7 +10,7 @@ app.config['SWAGGER'] = {
     'title': 'Colors API',
     'uiversion': 2
 }
-Swagger(app, template_file='colors_template.json')
+swag = Swagger(app, template_file='colors_template.json')
 
 
 @app.route('/colors/<palette>/')

--- a/examples/colors_with_schema.py
+++ b/examples/colors_with_schema.py
@@ -52,7 +52,7 @@ class PaletteView(SwaggerView):
 
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 app.add_url_rule(
     '/colors/<palette>',

--- a/examples/compat.py
+++ b/examples/compat.py
@@ -18,7 +18,7 @@ app.config['SWAGGER'] = {
     # $ref: '#/definitions/index_post_alert'
     'prefix_ids': True
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 @app.route('/', methods=['POST'])

--- a/examples/decorator_package.py
+++ b/examples/decorator_package.py
@@ -6,7 +6,7 @@ from flask import Flask, jsonify
 from flasgger import Swagger
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 
 @decorator

--- a/examples/marshmallow_apispec.py
+++ b/examples/marshmallow_apispec.py
@@ -13,7 +13,7 @@ app.config['SWAGGER'] = {
     "uiversion": 2
 }
 
-Swagger(app)
+swag = Swagger(app)
 
 
 class User(Schema):

--- a/examples/restful.py
+++ b/examples/restful.py
@@ -13,7 +13,7 @@ app.config['SWAGGER'] = {
     'title': 'Flasgger RESTful',
     'uiversion': 2
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 TODOS = {

--- a/examples/top_level_vendor_extension.py
+++ b/examples/top_level_vendor_extension.py
@@ -11,7 +11,7 @@ app.config['SWAGGER'] = {
     'uiversion': 2,
     'x-groupTag': 'Test',
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 def test_swag(client, specs_data):

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -6,7 +6,7 @@ from flask import Blueprint, Flask, jsonify, request
 from flasgger import Schema, Swagger, SwaggerView, fields, swag_from, validate
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 
 @app.route("/manualvalidation", methods=['POST'])


### PR DESCRIPTION
conftest assumes that `specs_route` will always be "/apidocs/".

This PR makes conftest to check if there is a reference to the Swagger object and if so it will pull `specs_route` from Swagger's `config` instance variable.