### PR TITLE
Custom specs_route example

### DIFF
--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -67,8 +67,8 @@ template = apispec_to_template(
 
 """
 
-# start Flsgger using a template from apispec
-Swagger(app, template=template)
+# start Flasgger using a template from apispec
+swag = Swagger(app, template=template)
 
 
 if __name__ == '__main__':

--- a/examples/base_model_view.py
+++ b/examples/base_model_view.py
@@ -64,7 +64,7 @@ class PostAPIView(ModelAPIView):
 
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 app.add_url_rule(
     '/user/<team_id>',

--- a/examples/basic_auth.py
+++ b/examples/basic_auth.py
@@ -49,7 +49,7 @@ app.config["SWAGGER"] = {
     "title": "Swagger Basic Auth App",
     "uiversion": 2,
 }
-Swagger(app,
+swag = Swagger(app,
     decorators=[ requires_basic_auth ],
     template={
         "swagger": "2.0",

--- a/examples/colors_from_specdict.py
+++ b/examples/colors_from_specdict.py
@@ -11,7 +11,7 @@ app.config['SWAGGER'] = {
     'title': 'Colors API',
     'uiversion': 2
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 colors_spec = {

--- a/examples/colors_template_json.py
+++ b/examples/colors_template_json.py
@@ -10,7 +10,7 @@ app.config['SWAGGER'] = {
     'title': 'Colors API',
     'uiversion': 2
 }
-Swagger(app, template_file='colors_template.json')
+swag = Swagger(app, template_file='colors_template.json')
 
 
 @app.route('/colors/<palette>/')

--- a/examples/colors_with_schema.py
+++ b/examples/colors_with_schema.py
@@ -52,7 +52,7 @@ class PaletteView(SwaggerView):
 
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 app.add_url_rule(
     '/colors/<palette>',

--- a/examples/compat.py
+++ b/examples/compat.py
@@ -18,7 +18,7 @@ app.config['SWAGGER'] = {
     # $ref: '#/definitions/index_post_alert'
     'prefix_ids': True
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 @app.route('/', methods=['POST'])

--- a/examples/decorator_package.py
+++ b/examples/decorator_package.py
@@ -6,7 +6,7 @@ from flask import Flask, jsonify
 from flasgger import Swagger
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 
 @decorator

--- a/examples/marshmallow_apispec.py
+++ b/examples/marshmallow_apispec.py
@@ -13,7 +13,7 @@ app.config['SWAGGER'] = {
     "uiversion": 2
 }
 
-Swagger(app)
+swag = Swagger(app)
 
 
 class User(Schema):

--- a/examples/restful.py
+++ b/examples/restful.py
@@ -13,7 +13,7 @@ app.config['SWAGGER'] = {
     'title': 'Flasgger RESTful',
     'uiversion': 2
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 TODOS = {

--- a/examples/specs_route_example.py
+++ b/examples/specs_route_example.py
@@ -1,0 +1,43 @@
+"""
+In this example a custom specs_route is set.
+"""
+from flask import Flask
+try:
+    from http import HTTPStatus
+except ImportError:
+    import httplib as HTTPStatus
+from flasgger import Swagger
+
+swagger_config = {
+    "headers": [
+    ],
+    "specs": [
+        {
+            "endpoint": 'specifications',
+            "route": '/specifications.json',
+            "rule_filter": lambda rule: True,  # all in
+            "model_filter": lambda tag: True,  # all in
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    # "static_folder": "static",  # must be set by user
+    "specs_route": "/documentation/swagger/"
+}
+
+app = Flask(__name__)
+swag = Swagger(app, config=swagger_config)
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    assert client.get('/documentation/swagger/').status_code == HTTPStatus.OK
+    assert specs_data.get('/specifications.json') is not None
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/examples/top_level_vendor_extension.py
+++ b/examples/top_level_vendor_extension.py
@@ -11,7 +11,7 @@ app.config['SWAGGER'] = {
     'uiversion': 2,
     'x-groupTag': 'Test',
 }
-Swagger(app)
+swag = Swagger(app)
 
 
 def test_swag(client, specs_data):

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -6,7 +6,7 @@ from flask import Blueprint, Flask, jsonify, request
 from flasgger import Schema, Swagger, SwaggerView, fields, swag_from, validate
 
 app = Flask(__name__)
-Swagger(app)
+swag = Swagger(app)
 
 
 @app.route("/manualvalidation", methods=['POST'])


### PR DESCRIPTION
Include missing test case for custom `specs_route` configuration

Depends on #116 (This PR starts at commit [d10c43d](https://github.com/rochacbruno/flasgger/pull/117/commits/d10c43d98b845aa3b0ab00966ac2542efbedb4b6))