### PR TITLE
Fix views registering when Swagger UI is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ external APP.
 
 # Customize default configurations
 
-Custom configurations such as a different specs route can be provided to Flasgger:
+Custom configurations such as a different specs route or disabling Swagger UI can be provided to Flasgger:
 
 ```python
 swagger_config = {

--- a/examples/disable_swagger_ui.py
+++ b/examples/disable_swagger_ui.py
@@ -2,7 +2,10 @@
 In this example Swagger UI is disabled.
 """
 from flask import Flask
-
+try:
+    from http import HTTPStatus
+except ImportError:
+    import httplib as HTTPStatus
 from flasgger import Swagger
 
 swagger_config = {
@@ -30,8 +33,10 @@ def test_swag(client, specs_data):
     :param client: Flask app test client
     :param specs_data: {'url': {swag_specs}} for every spec in app
     """
-    
+
     assert not specs_data
+    assert client.get('/apidocs/').status_code == HTTPStatus.NOT_FOUND
+    assert client.get('/apispec.json').status_code == HTTPStatus.OK
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
When Swagger UI is disabled the swagger specification was not being served.

This PR fixes it, updates README to better hint the use of `swagger_ui` flag and enhances a test case to check if the JSON OpenAPI specs endpoint is served correctly independent from the Swagger UI.