### PR TITLE
Support validation against specs in docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ from flask import Flask, jsonify
 from flasgger import Swagger
 
 app = Flask(__name__)
-Swagger(app)
+swagger = Swagger(app)
 
 @app.route('/colors/<palette>/')
 def colors(palette):
@@ -287,7 +287,7 @@ class PaletteView(SwaggerView):
         return jsonify(result)
 
 app = Flask(__name__)
-Swagger(app)
+swagger = Swagger(app)
 
 app.add_url_rule(
     '/colors/<palette>',
@@ -317,7 +317,7 @@ from flask_restful import Api, Resource
 
 app = Flask(__name__)
 api = Api(app)
-Swagger(app)
+swagger = Swagger(app)
 
 class Username(Resource):
     def get(self, username):
@@ -426,17 +426,17 @@ By default Flasgger will try to sanitize the content in YAML definitions
 replacing every ```\n``` with ```<br>``` but you can change this behaviour
 setting another kind of sanitizer.
 
-```
+```python
 from flasgger import Swagger, NO_SANITIZER
 
 app =Flask()
-Swagger(app, sanitizer=NO_SANITIZER)
+swagger = Swagger(app, sanitizer=NO_SANITIZER)
 ```
 
 You can write your own sanitizer
 
-```
-Swagger(app, sanitizer=lambda text: do_anything_with(text))
+```python
+swagger = Swagger(app, sanitizer=lambda text: do_anything_with(text))
 ```
 
 There is also a Markdown parser available, if you want to be able to render
@@ -458,7 +458,7 @@ app.config['SWAGGER'] = {
     'title': 'My API',
     'uiversion': 3
 }
-Swagger(app)
+swagger = Swagger(app)
 
 ```
 
@@ -535,7 +535,7 @@ from flask import Flask, jsonify
 from flasgger import Swagger
 
 app = Flask(__name__)
-Swagger(app)
+swagger = Swagger(app)
 
 @app.route('/colors/<palette>/')
 def colors(palette):

--- a/README.md
+++ b/README.md
@@ -374,23 +374,41 @@ registering the `url_rule` many times. Take a look at `examples/example_app`
 
 # Use the same data to validate your API POST body.
 
-```python
-from flasgger import swag_from, validate
-
-@swag_from('defs.yml')
-def post():
-    validate(request.json, 'UserSchema', 'defs.yml')
-    # if not validate returns ValidationError response with status 400
-    # also returns the validation message.
-```
-
-You can also tell `swag_from` to validate automatically
+Setting `swag_from`'s _validation_ parameter to `True` will validate incoming data automatically:
 
 ```python
 from flasgger import swag_from
 
 @swag_from('defs.yml', validation=True)
 def post():
+    # if not validate returns ValidationError response with status 400
+    # also returns the validation message.
+```
+
+Using `swagger.validate` annotation is also possible:
+
+```python
+from flasgger import Swagger
+
+swagger = Swagger(app)
+
+@swagger.validate('UserSchema')
+def post():
+    '''
+    file: defs.yml
+    '''
+    # if not validate returns ValidationError response with status 400
+    # also returns the validation message.
+```
+
+Yet you can call `validate` manually:
+
+```python
+from flasgger import swag_from, validate
+
+@swag_from('defs.yml')
+def post():
+    validate(request.json, 'UserSchema', 'defs.yml')
     # if not validate returns ValidationError response with status 400
     # also returns the validation message.
 ```


### PR DESCRIPTION
Despite Flasgger supports defining the specs in the docstring, when one wants automatic POST requests data validation it is not supported doing so if the swagger specifications are defined in the docstring.

This PR adds support for that through a new `validate` annotation:
```python
swagger = Swagger(app)

@app.route('/pets', methods=['POST'])
@swagger.validate('Pet')
def post():
    """
    Pet POST endpoint
    ---
    tags:
      - pet
    parameters:
      - name: body
        in: body
        required: true
        schema:
          id: Pet
          required:
            - name
          properties:
            name:
              type: string
              description: The pet's name.
              default: "Rex"
            tags:
              type: array
              description: optional list of tags
              default: ["bulldog"]
              items:
                type: string

    responses:
      200:
        description: A single pet item
        schema:
          $ref: '#/definitions/Pet'
    """
    return db.insert(request.data)
```