### PR TITLE
Emend README incorrect example template

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,10 +484,8 @@ template = {
   "host": "mysite.com",  # overrides localhost:500
   "basePath": "/api",  # base bash for blueprint registration
   "schemes": [
-    [
-      "http",
-      "https"
-    ]
+    "http",
+    "https"
   ],
   "operationId": "getmyData"
 }


### PR DESCRIPTION
In **Initializing Flasgger with default data.** README section:

```json
    "schemes": [
        [
          "http",
          "https"
        ]
      ],
```

Is invalid `schemes` format, should be a list of strings, and will render an invalid Swagger specification error in [online.swagger.io/validator](https://online.swagger.io/validator)