### PR TITLE
Get defined schemas as python dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,56 @@ Take a look at `examples/validation.py` for more information.
 
 All validation options can be found at http://json-schema.org/latest/json-schema-validation.html
 
+# Get defined schemas as python dictionaries
+
+You may wish to use schemas you defined in your Swagger specs as dictionaries
+without replicating the specification. For that you can use the `get_schema`
+method:
+
+```python
+from flask import Flask, jsonify
+from flasgger import Swagger, swag_from
+
+app = Flask(__name__)
+swagger = Swagger(app)
+
+@swagger.validate('Product')
+def post():
+    """
+    post endpoint
+    ---
+    tags:
+      - products
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          id: Product
+          required:
+            - name
+          properties:
+            name:
+              type: string
+              description: The product's name.
+              default: "Guarana"
+    responses:
+      200:
+        description: The product inserted in the database
+        schema:
+          $ref: '#/definitions/Product'
+    """
+    rv = db.insert(request.json)
+    return jsonify(rv)
+
+...
+
+product_schema = swagger.get_schema('product')
+```
+
+This method returns a dictionary which contains the Flasgger schema id,
+all defined parameters and a list of required parameters.
+
 # HTML sanitizer
 
 By default Flasgger will try to sanitize the content in YAML definitions

--- a/examples/get_schema.py
+++ b/examples/get_schema.py
@@ -59,7 +59,10 @@ def test_swag(client, specs_data):
 
     retrieved_schema = json.loads(response.data.decode('utf-8'))
     actual_schema = specs_data['/apispec_1.json']['definitions']['Officer']
-    assert retrieved_schema.items() >= actual_schema.items()
+    try:
+        assert retrieved_schema.viewitems() >= actual_schema.viewitems()
+    except AttributeError:
+        assert retrieved_schema.items() >= actual_schema.items()
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/get_schema.py
+++ b/examples/get_schema.py
@@ -1,0 +1,65 @@
+try:
+    import simplejson as json
+except ImportError:
+    import json
+try:
+    from http import HTTPStatus
+except ImportError:
+    import httplib as HTTPStatus
+from flask import Flask
+from flask import jsonify
+from flasgger import Swagger
+from flasgger import swag_from
+
+app = Flask(__name__)
+swag = Swagger(app)
+
+
+@app.route("/officer/<int:priority>", methods=['POST'])
+@swag_from("officer_specs.yml")
+def create_officer(priority):
+    return 'Request for officer creation successfully received' \
+           ' (priority: %i)'.format(priority), HTTPStatus.OK
+
+
+@app.route('/schema/<string:schema_id>', methods=['GET'])
+def get_schema(schema_id):
+    """
+    Test schema retrieval
+
+    This endpoint returns a schema known to Flasgger
+    ---
+    tags:
+      - schema
+    produces:
+      - application/json
+    parameters:
+      - in: path
+        name: schema_id
+        type: string
+        description: schema_id to be retrieved
+        required: true
+
+    responses:
+      200:
+        description: The requested schema
+    """
+    return jsonify(swag.get_schema(schema_id)), HTTPStatus.OK
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    response = client.get('/schema/officer')
+    assert response.status_code == HTTPStatus.OK
+
+    retrieved_schema = json.loads(response.data.decode('utf-8'))
+    actual_schema = specs_data['/apispec_1.json']['definitions']['Officer']
+    assert retrieved_schema.items() >= actual_schema.items()
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/officer_specs.yml
+++ b/examples/officer_specs.yml
@@ -35,6 +35,6 @@ parameters:
 
 responses:
   200:
-    description: A single officer item
+    description: The officer inserted in the database
     schema:
       $ref: '#/definitions/Officer'

--- a/examples/officer_specs.yml
+++ b/examples/officer_specs.yml
@@ -1,0 +1,40 @@
+Officer creation endpoint
+---
+tags:
+  - officer
+parameters:
+  - name: priority
+    in: path
+    type: integer
+    description: level of priority
+    required: true
+    default: 4
+  - name: body
+    in: body
+    required: true
+    schema:
+      id: Officer
+      required:
+        - name
+        - age
+      properties:
+        name:
+          type: string
+          description: The officer's name.
+          default: "James T. Kirk"
+        age:
+          type: integer
+          description: The officer's age (should be integer)
+          default: 138
+        tags:
+          type: array
+          description: optional list of tags
+          default: ["starfleet", "captain", "enterprise", "dead"]
+          items:
+            type: string
+
+responses:
+  200:
+    description: A single officer item
+    schema:
+      $ref: '#/definitions/Officer'

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -474,7 +474,11 @@ class Swagger(object):
         return decorator
 
     def get_schema(self, schema_id):
-        return get_schema_specs(schema_id, self)['parameters'][0]['schema']
+        for schema in (
+                parameter.get('schema') for parameter in
+                get_schema_specs(schema_id, self)['parameters']):
+            if schema is not None and schema.get('id').lower() == schema_id:
+                return schema
 
 
 # backwards compatibility

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -453,7 +453,7 @@ class Swagger(object):
 
         This annotation only works if the endpoint is already swagged,
         i.e. placing @swag_from above @validate or not declaring the
-        swagger specifications in the method's docstring **won't work**
+        swagger specifications in the method's docstring *won't work*
 
         Naturally, if you use @app.route annotation it still needs to
         be the outermost annotation
@@ -474,9 +474,22 @@ class Swagger(object):
         return decorator
 
     def get_schema(self, schema_id):
+        """
+        This method finds a schema known to Flasgger and returns it.
+
+        :raise KeyError: when the specified :param schema_id: is not
+        found by Flasgger
+
+        :param schema_id: the id of the desired schema
+        """
+        schema_specs = get_schema_specs(schema_id, self)
+
+        if schema_specs is None:
+            raise KeyError('Specified schema_id \'{0}\' not found')
+
         for schema in (
                 parameter.get('schema') for parameter in
-                get_schema_specs(schema_id, self)['parameters']):
+                schema_specs['parameters']):
             if schema is not None and schema.get('id').lower() == schema_id:
                 return schema
 


### PR DESCRIPTION
Despite Flasgger gathers up all defined schemas it does not exposes an interfacing method to enable querying them. This PR adds this missing interfacing method: `Swagger::get_schema(schema_id)`

This may be useful when an application needs to access the schema for further validation steps, such as dropping additional parameters in a request body.