### PR TITLE
Custom validation functions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,9 +425,10 @@ All validation options can be found at http://json-schema.org/latest/json-schema
 By default Flasgger will use [python-jsonschema](https://python-jsonschema.readthedocs.io/en/latest/)
 to perform validation.
 
-Custom validation functions are supported as long as they take two
-positional arguments: the data to be validated as:
- - the first and the schema to validate against as the second argument; and
+Custom validation functions are supported as long as they meet the requirements:
+ - take two, and only two, positional arguments:
+    - the data to be validated as the first; and
+    - the schema to validate against as the second argument
  - raise any kind of exception when validation fails.
 
 Any return value is discarded.

--- a/README.md
+++ b/README.md
@@ -420,6 +420,56 @@ Take a look at `examples/validation.py` for more information.
 
 All validation options can be found at http://json-schema.org/latest/json-schema-validation.html
 
+### Custom validation
+
+By default Flasgger will use [python-jsonschema](https://python-jsonschema.readthedocs.io/en/latest/)
+to perform validation.
+
+Custom validation functions are supported as long as they take two
+positional arguments: the data to be validated as:
+ - the first and the schema to validate against as the second argument; and
+ - raise any kind of exception when validation fails.
+
+Any return value is discarded.
+
+
+Providing the function to the Swagger instance will make it the default:
+
+```python
+from flasgger import Swagger
+
+swagger = Swagger(app, validation_function=my_validation_function)
+```
+
+Providing the function as parameter of `swag_from` or `swagger.validate`
+annotations or directly to the `validate` function will force it's use
+over the default validation function for Swagger:
+
+```python
+from flasgger import swag_from
+
+@swag_from('spec.yml', validation=True, validation_function=my_function)
+...
+```
+
+```python
+from flasgger import Swagger
+
+swagger = Swagger(app)
+
+@swagger.validate('Pet', validation_function=my_function)
+...
+```
+
+```python
+from flasgger import validate
+
+...
+
+    validate(
+        request.json, 'Pet', 'defs.yml', validation_function=my_function)
+```
+
 # Get defined schemas as python dictionaries
 
 You may wish to use schemas you defined in your Swagger specs as dictionaries

--- a/examples/custom_validation_function.py
+++ b/examples/custom_validation_function.py
@@ -1,3 +1,4 @@
+import time
 import jsonschema
 try:
     import simplejson as json
@@ -12,7 +13,7 @@ from flask import request
 from flasgger import Swagger
 
 
-def validate(data, schema):
+def drop_id_validate(data, schema):
     """
     Custom validation function which drops parameter '_id' if present
     in data
@@ -22,15 +23,41 @@ def validate(data, schema):
         del data['_id']
 
 
+def timestamping_validate(data, schema):
+    """
+    Custom validation function which inserts a timestamp for when the
+    validation occurred
+    """
+    jsonschema.validate(data, schema)
+    data['timestamp'] = str(time.time())
+
+
+def special_validate(data, schema):
+    """
+    Custom validation function which inserts an special flag depending
+    on the cat's name
+    """
+    jsonschema.validate(data, schema)
+    data['special'] = str(data['name'] == 'Garfield').lower()
+
+
+def regular_validate(data, schema):
+    """
+    Regular validation function
+    """
+    jsonschema.validate(data, schema)
+
+
 app = Flask(__name__)
-swag = Swagger(app, validation_function=validate)
+swag = Swagger(app, validation_function=drop_id_validate)
 
 
 @app.route('/cat', methods=['POST'])
 @swag.validate('Cat')
 def create_cat():
     """
-    Cat creation endpoint
+    Cat creation endpoint which drops '_id' parameters when present in
+    request data
     ---
     tags:
       - cat
@@ -68,6 +95,102 @@ def create_cat():
     return jsonify(request.json), HTTPStatus.OK
 
 
+@app.route('/timestamped/cat', methods=['POST'])
+@swag.validate('Cat', validation_function=timestamping_validate)
+def create_timestamped_cat():
+    """
+    Cat creation endpoint which timestamps validated data
+    ---
+    tags:
+      - cat
+    summary: Creates a new cat
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        description:
+          Cat object that needs to be persisted to the database
+        required: true
+        schema:
+          $ref: '#/definitions/Cat'
+    responses:
+      200:
+        description: Successful operation
+        schema:
+          $ref: '#/definitions/Cat'
+      400:
+        description: Invalid input
+    """
+    return jsonify(request.json), HTTPStatus.OK
+
+
+@app.route('/special/cat', methods=['POST'])
+@swag.validate('Cat', validation_function=special_validate)
+def create_special_cat():
+    """
+    Cat creation endpoint which timestamps validated data
+    ---
+    tags:
+      - cat
+    summary: Creates a new cat
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        description:
+          Cat object that needs to be persisted to the database
+        required: true
+        schema:
+          $ref: '#/definitions/Cat'
+    responses:
+      200:
+        description: Successful operation
+        schema:
+          $ref: '#/definitions/Cat'
+      400:
+        description: Invalid input
+    """
+    return jsonify(request.json), HTTPStatus.OK
+
+
+@app.route('/regular/cat', methods=['POST'])
+@swag.validate('Cat', validation_function=regular_validate)
+def create_regular_cat():
+    """
+    Cat creation endpoint
+    ---
+    tags:
+      - cat
+    summary: Creates a new cat
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        description:
+          Cat object that needs to be persisted to the database
+        required: true
+        schema:
+          $ref: '#/definitions/Cat'
+    responses:
+      200:
+        description: Successful operation
+        schema:
+          $ref: '#/definitions/Cat'
+      400:
+        description: Invalid input
+    """
+    return jsonify(request.json), HTTPStatus.OK
+
+
 def test_swag(client, specs_data):
     """
     This test is runs automatically in Travis CI
@@ -83,16 +206,64 @@ def test_swag(client, specs_data):
           "address": "MGM, 245 N. Beverly Drive, Beverly Hills, CA 90210"
         }
         """
-    response = client.post('/cat', data=cat, content_type='application/json')
-    assert response.status_code == HTTPStatus.OK
+    with client.post(
+            '/cat', data=cat, content_type='application/json') as response:
+        assert response.status_code == HTTPStatus.OK
 
-    sent = json.loads(cat)
-    received = json.loads(response.data.decode('utf-8'))
-    assert received.get('_id') is None
-    try:
-        assert received.viewitems() < sent.viewitems()
-    except AttributeError:
-        assert received.items() < sent.items()
+        sent = json.loads(cat)
+        received = json.loads(response.data.decode('utf-8'))
+        assert received.get('_id') is None
+        assert received.get('timestamp') is None
+        assert received.get('special') is None
+        try:
+            assert received.viewitems() < sent.viewitems()
+        except AttributeError:
+            assert received.items() < sent.items()
+
+    with client.post(
+            '/timestamped/cat', data=cat,
+            content_type='application/json') as response:
+        assert response.status_code == HTTPStatus.OK
+
+        sent = json.loads(cat)
+        received = json.loads(response.data.decode('utf-8'))
+        assert received.get('_id') == sent.get('_id')
+        assert received.get('timestamp') is not None
+        assert received.get('special') is None
+        try:
+            assert received.viewitems() > sent.viewitems()
+        except AttributeError:
+            assert received.items() > sent.items()
+
+    with client.post(
+            '/special/cat', data=cat,
+            content_type='application/json') as response:
+        assert response.status_code == HTTPStatus.OK
+
+        sent = json.loads(cat)
+        received = json.loads(response.data.decode('utf-8'))
+        assert received.get('_id') == sent.get('_id')
+        assert received.get('timestamp') is None
+        assert received.get('special') is not None
+        try:
+            assert received.viewitems() > sent.viewitems()
+        except AttributeError:
+            assert received.items() > sent.items()
+
+    with client.post(
+            '/regular/cat', data=cat,
+            content_type='application/json') as response:
+        assert response.status_code == HTTPStatus.OK
+
+        sent = json.loads(cat)
+        received = json.loads(response.data.decode('utf-8'))
+        assert received.get('_id') == sent.get('_id')
+        assert received.get('timestamp') is None
+        assert received.get('special') is None
+        try:
+            assert received.viewitems() == sent.viewitems()
+        except AttributeError:
+            assert received.items() == sent.items()
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/custom_validation_function.py
+++ b/examples/custom_validation_function.py
@@ -1,0 +1,98 @@
+import jsonschema
+try:
+    import simplejson as json
+except ImportError:
+    import json
+try:
+    from http import HTTPStatus
+except ImportError:
+    import httplib as HTTPStatus
+from flask import Flask, jsonify
+from flask import request
+from flasgger import Swagger
+
+
+def validate(data, schema):
+    """
+    Custom validation function which drops parameter '_id' if present
+    in data
+    """
+    jsonschema.validate(data, schema)
+    if data.get('_id') is not None:
+        del data['_id']
+
+
+app = Flask(__name__)
+swag = Swagger(app, validation_function=validate)
+
+
+@app.route('/cat', methods=['POST'])
+@swag.validate('Cat')
+def create_cat():
+    """
+    Cat creation endpoint
+    ---
+    tags:
+      - cat
+    summary: Creates a new cat
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        description:
+          Cat object that needs to be persisted to the database
+        required: true
+        schema:
+          id: Cat
+          required:
+            - name
+            - address
+          properties:
+            name:
+              description: Cat's name
+              type: string
+              example: Sylvester
+            address:
+              description: Cat's house address
+              type: string
+              example: 4000 Warner Blvd., Burbank, CA 91522
+    responses:
+      200:
+        description: Successful operation
+      400:
+        description: Invalid input
+    """
+    return jsonify(request.json), HTTPStatus.OK
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    cat = \
+        """
+        {
+          "_id": "594dba7b2879334e411f3dcc",
+          "name": "Tom",
+          "address": "MGM, 245 N. Beverly Drive, Beverly Hills, CA 90210"
+        }
+        """
+    response = client.post('/cat', data=cat, content_type='application/json')
+    assert response.status_code == HTTPStatus.OK
+
+    sent = json.loads(cat)
+    received = json.loads(response.data.decode('utf-8'))
+    assert received.get('_id') is None
+    try:
+        assert received.viewitems() < sent.viewitems()
+    except AttributeError:
+        assert received.items() < sent.items()
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -57,6 +57,7 @@ class SwaggerView(MethodView):
     summary = None
     description = None
     validation = False
+    validation_function = None
 
     def dispatch_request(self, *args, **kwargs):
         """
@@ -73,7 +74,8 @@ class SwaggerView(MethodView):
             definitions = {}
             specs.update(convert_schemas(specs, definitions))
             specs['definitions'] = definitions
-            flasgger.utils.validate(specs=specs)
+            flasgger.utils.validate(
+                specs=specs, validation_function=self.validation_function)
         return super(SwaggerView, self).dispatch_request(*args, **kwargs)
 
 


### PR DESCRIPTION
It may be useful to allow the caller to provide their own validation functions.

This PR adds support for overriding the default validation function globally or on a per-context basis.