### PR TITLE
Update utils.py

### DIFF
--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -103,6 +103,7 @@ def get_specs(rules, ignore_verbs, optional_fields, sanitizer):
                 swag.update(
                     convert_schemas(apispec_swag, apispec_definitions)
                 )
+                swag['definitions'] = apispec_definitions
 
                 swagged = True
 


### PR DESCRIPTION
auto generate swag definitions from parameters, responses. 
implementation adopted from `marshmallow_apispec.py` line 76


before this, needs to define `definition` explicitly in SchemaView as:
```python
class PaletteView(SwaggerView):
    validation = True
    definitions = {'Palette': Palette, 'Color': Color, 'PaletteInputSchema': PaletteInputSchema}
    parameters = PaletteInputSchema
    responses = {
        200: {
            "description": "A list of colors (may be filtered by palette)",
            "schema": Palette
        }
    }
```
otherwise, apidoc cannot display request/response schema:
<img width="1039" alt="screen shot 2017-08-03 at 12 37 42 pm" src="https://user-images.githubusercontent.com/221029/28906223-9c8434b0-7848-11e7-85e0-306177298df5.png">

with the update, `definitions` are generated from `parameters` and `responses`
```python

class PaletteView(SwaggerView):
    validation = True
    #definitions = {'Palette': Palette, 'Color': Color, 'PaletteInputSchema': PaletteInputSchema}
    parameters = PaletteInputSchema
    responses = {
        200: {
            "description": "A list of colors (may be filtered by palette)",
            "schema": Palette
        }
    }
```
<img width="1025" alt="screen shot 2017-08-03 at 12 40 13 pm" src="https://user-images.githubusercontent.com/221029/28906280-02df2e22-7849-11e7-8e9a-5d52dc1729dc.png">
