### PR TITLE
Move dev dependencies to requirements-dev.txt

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -15,3 +15,4 @@ pep8:
 
 requirements:
     - requirements.txt
+    - requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 before_install:
   - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
 
 script:
   - make test

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,8 @@ Please contribute adding your example to increase our test coverage
 
 The only rules to follow is:
 
-- Add extra requirements to `requirements.txt`
+- Add extra production requirements to `requirements.txt` and `setup.py`
+- Add extra development requirements to `requirements-dev.txt`
 - use `if __name__ == '__main__':` before `app.run()`
 
 # testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# optional (for dev)
+marshmallow
+apispec
+flask-restful
+pep8==1.5.7
+flake8==2.4.1
+pytest>=3.0.7
+flex
+coveralls
+pytest-cov
+decorator
+wheel
+
+# install flasgger itself as editable
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,3 @@ PyYAML>=3.0
 jsonschema>=2.5.1
 six>=1.10.0
 mistune
-
-# optional (for dev)
-marshmallow
-apispec
-flask-restful
-pep8==1.5.7
-flake8==2.4.1
-pytest>=3.0.7
-flex
-coveralls
-pytest-cov
-decorator
-wheel
-
-# install flasgger itself as editable
--e .

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,4 @@ commands =
     make test
 deps =
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
So we can keep a clean separation of what is needed in production and
development.