### PR TITLE
Merge specs_dict recursively instead of just updating the top level

### DIFF
--- a/examples/swag_from_merging.py
+++ b/examples/swag_from_merging.py
@@ -1,0 +1,48 @@
+from flask import Flask
+from flask import jsonify
+from flasgger import Swagger
+from flasgger import swag_from
+
+app = Flask(__name__)
+swag = Swagger(app)
+
+
+@app.route("/example")
+@swag_from({
+    "responses": {
+        400: {
+            "description": "Invalid action"
+        },
+        401: {
+            "description": "Login required"
+        }
+    },
+    "tags": ["Tag 1", "Tag 2"]
+})
+def view():
+    """
+    A test view
+
+    ---
+    responses:
+      200:
+        description: OK
+    tags: [Tag 3, Tag 4]
+    """
+    return jsonify(hello="world")
+
+
+def test_swag(client, specs_data):
+    example_spec = specs_data["/apispec_1.json"]["paths"]["/example"]["get"]
+    assert "400" in example_spec["responses"]
+    assert "401" in example_spec["responses"]
+    assert "200" in example_spec["responses"]
+
+    assert "Tag 1" in example_spec["tags"]
+    assert "Tag 2" in example_spec["tags"]
+    assert "Tag 3" in example_spec["tags"]
+    assert "Tag 4" in example_spec["tags"]
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/swag_from_overriding.py
+++ b/examples/swag_from_overriding.py
@@ -1,0 +1,45 @@
+from flask import Flask
+from flask import jsonify
+from flasgger import Swagger
+from flasgger import swag_from
+
+app = Flask(__name__)
+swag = Swagger(app)
+
+
+@app.route("/example")
+@swag_from({
+    "responses": {
+        400: {
+            "description": "Invalid action"
+        },
+        401: {
+            "description": "Login required"
+        }
+    }
+})
+def view():
+    """
+    A test view
+
+    ---
+    responses:
+      200:
+        description: OK
+      400:
+        description: Modified description
+    """
+    return jsonify(hello="world")
+
+
+def test_swag(client, specs_data):
+    example_spec = specs_data["/apispec_1.json"]["paths"]["/example"]["get"]
+    assert "400" in example_spec["responses"]
+    assert "401" in example_spec["responses"]
+    assert "200" in example_spec["responses"]
+
+    assert example_spec["responses"]["400"]["description"] == "Modified description"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
Closes #172. This allows me to implement a decorator that prefills some parts of the documentation for the decorated function. These can later be extended with swagger yaml in the doc block.