### PR TITLE
Fix #162, the 'Not defined!' error on using with Marshmallow Schema

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -86,7 +86,11 @@ def convert_schemas(d, definitions=None):
     if Schema is None:
         raise RuntimeError('Please install marshmallow and apispec')
 
+    if definitions is None:
+        definitions = {}
+
     new = {}
+    new['definitions'] = definitions
     for k, v in d.items():
         if isinstance(v, dict):
             v = convert_schemas(v, definitions)
@@ -112,5 +116,5 @@ def convert_schemas(d, definitions=None):
             new[k] = v
 
         if k == 'definitions':
-            new['definitions'] = definitions
+            definitions.update(v)
     return new

--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -88,9 +88,9 @@ def convert_schemas(d, definitions=None):
 
     if definitions is None:
         definitions = {}
+    definitions.update(d.get('definitions', {}))
 
-    new = {}
-    new['definitions'] = definitions
+    new = {'definitions': definitions}
     for k, v in d.items():
         if isinstance(v, dict):
             v = convert_schemas(v, definitions)
@@ -115,6 +115,4 @@ def convert_schemas(d, definitions=None):
         else:
             new[k] = v
 
-        if k == 'definitions':
-            definitions.update(v)
     return new


### PR DESCRIPTION
Hi maintainers,

Thank you for this package, I'm working on API and this helps making docs so much.

However, I'm being trouble with using Marshmallow Schema, the issue addressed in #162.
The problem happens in `marshmallow_apispec.convert_schema()` function and I've worked to let it work. Could you review this PR?

Now the return value of the function does not include `'definitions'` field unless the passed `d` has the field.  I've changed this as:

  - Let return value always have 'definitions' field and add the schema definitions to it.
  - The priority of definitions is set as those used in `Schema` definitions > `'definitions'` fields in `d` > `definitions` argument.

The below are the Swagger docs shown when running `examples/marshmallow_apispec.py`.

Current master:
![marshmallow_api_before](https://user-images.githubusercontent.com/729653/34466549-57c150d4-ef1b-11e7-9fc1-cb7d593a18f6.png)

This branch:
![marshmallow_api_after](https://user-images.githubusercontent.com/729653/34466550-580c170e-ef1b-11e7-9051-babec8373477.png)

Now the Marshmallow Schema works, but I'm quite new to this project and not so sure about this change will suite the rest of the project.
Thanks!