### PR TITLE
Add support for NGINX Reverse Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,23 @@ Swagger(app, template=template)
 
 The `LazyString` values will be evaluated only when `jsonify` encodes the value at runtime, so you have access to Flask `request, session, g, etc..` and also may want to access a database.
 
+## Behind a reverse proxy
+
+Sometimes you're serving your swagger docs behind an reverse proxy (e.g. NGINX).  When following the [Flask guidance](http://flask.pocoo.org/snippets/35/),
+the swagger docs will load correctly, but the "Try it Out" button points to the wrong place.  This can be fixed with the following code:
+
+```python
+from flask import Flask, request
+from flask import Swagger, LazyString, LazyJSONEncoder
+
+app = Flask(__name__)
+app.json_encoder = LazyJSONEncoder
+
+template = dict(swaggerUiPrefix=LazyString(lambda : request.environ.get('HTTP_X_SCRIPT_NAME', '')))
+swagger = Swagger(app, template=template)
+
+``` 
+
 # Customize default configurations
 
 Custom configurations such as a different specs route or disabling Swagger UI can be provided to Flasgger:

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -255,7 +255,8 @@ class APISpecsView(MethodView):
 
             if len(operations):
                 if self.template.get('swaggerUiPrefix'):
-                    srule = str('{0}{1}'.format(str(self.template['swaggerUiPrefix']), str(rule)))
+                    srule = str('{0}{1}'.format(
+                        str(self.template['swaggerUiPrefix']), str(rule)))
                 else:
                     srule = str(rule)
                 # old regex '(<(.*?\:)?(.*?)>)'

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -254,7 +254,10 @@ class APISpecsView(MethodView):
                 operations[verb] = operation
 
             if len(operations):
-                srule = str(rule)
+                if self.template.get('swaggerUiPrefix'):
+                    srule = str('{0}{1}'.format(str(self.template['swaggerUiPrefix']), str(rule)))
+                else:
+                    srule = str(rule)
                 # old regex '(<(.*?\:)?(.*?)>)'
                 for arg in re.findall('(<([^<>]*:)?([^<>]*)>)', srule):
                     srule = srule.replace(arg[0], '{%s}' % arg[2])

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -254,11 +254,12 @@ class APISpecsView(MethodView):
                 operations[verb] = operation
 
             if len(operations):
-                if self.template.get('swaggerUiPrefix'):
-                    srule = str('{0}{1}'.format(
-                        str(self.template['swaggerUiPrefix']), str(rule)))
-                else:
-                    srule = str(rule)
+                try:
+                    # Add reverse proxy prefix to route
+                    prefix = self.template['swaggerUiPrefix']
+                except (KeyError, TypeError):
+                    prefix = ''
+                srule = '{0}{1}'.format(prefix, rule)
                 # old regex '(<(.*?\:)?(.*?)>)'
                 for arg in re.findall('(<([^<>]*:)?([^<>]*)>)', srule):
                     srule = srule.replace(arg[0], '{%s}' % arg[2])


### PR DESCRIPTION
When running flasgger behind a reverse proxy, you can use these instructions to get the Flask routing to happen correctly (http://flask.pocoo.org/snippets/35/)

Add the following to your Flask App:

```python
from flask import Flask

class ReverseProxied(object):

    def __init__(self, app):
        self.app = app

    def __call__(self, environ, start_response):
        environ = self.update_environ(environ)
        return self.app(environ, start_response)

    @staticmethod
    def update_environ(environ):
        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
        if script_name:
            environ['SCRIPT_NAME'] = script_name
            path_info = environ['PATH_INFO']
            if path_info.startswith(script_name):
                environ['PATH_INFO'] = path_info[len(script_name):]

        scheme = environ.get('HTTP_X_SCHEME', '')
        if scheme:
            environ['wsgi.url_scheme'] = scheme

        return environ

app = Flask(__name__)
app.wsgi_app = ReverseProxied(app.wsgi_app)
```

Add the following to your NGINX config
```        
location /myapp/ {
        	proxy_pass		http://localhost:8888; 
        	proxy_set_header	Host $host:$server_port;
    		proxy_set_header	X-Forwarded-Proto $scheme;
    		proxy_set_header	X-Scheme $scheme;
    		proxy_set_header	X-Script-Name /myapp;
        }
```

In this situation, if your NGINX running at http://localhost:8000, when you access http://localhost:8000/myapp/apidocs, the swagger docs will correctly load from Flasgger.  However, the "Try It Out" link on an endpoint (http://localhost:8000/myapp/info) will not work because swagger routes to http://localhost:8000/info.  

This change allows the use of LazyString to grab the HTTP_X_SCRIPT_NAME header that is passed by NGINX and adds it to all of the paths in the swagger UI so that the docs will continue to load and the routes point to the right place.
