### PR TITLE
Authorization header using the Bearer schema

### DIFF
--- a/flasgger/ui2/templates/flasgger/index.html
+++ b/flasgger/ui2/templates/flasgger/index.html
@@ -81,7 +81,7 @@
               var tokenField = 'jwt-token';
               if (response.hasOwnProperty(tokenField)) {
                 var jwt_token = response[tokenField];
-                swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization("Authorization", "JWT " + jwt_token, "header"));
+                swaggerUi.api.clientAuthorizations.add("key", new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + jwt_token, "header"));
               }
             });
           {%- endif %}

--- a/flasgger/ui3/templates/flasgger/index.html
+++ b/flasgger/ui3/templates/flasgger/index.html
@@ -106,7 +106,7 @@ window.onload = function() {
     {% if config.JWT_AUTH_URL_RULE -%}
     requestInterceptor: function(request) {
       if (jwt_token) {
-        request.headers.Authorization = "JWT " + jwt_token;
+        request.headers.Authorization = "Bearer " + jwt_token;
       }
 
       return request;


### PR DESCRIPTION
User agent should send the JWT, typically in the Authorization header using the Bearer schema. The content of the header should look like the following:  Authorization: Bearer <token>

Refer : How do JSON Web Tokens work? 
Link : https://jwt.io/introduction/

Stack overflow Link : https://stackoverflow.com/a/33281233
