### PR TITLE
Update jwt_auth.py

### DIFF
--- a/examples/jwt_auth.py
+++ b/examples/jwt_auth.py
@@ -62,6 +62,7 @@ app.config["SWAGGER"] = {
     "title": "Swagger JWT Authentiation App",
     "uiversion": 3,
 }
+app.config['JWT_AUTH_URL_RULE'] ='/api/auth'
 
 swag = Swagger(app,
     template={


### PR DESCRIPTION
`{% if config.JWT_AUTH_URL_RULE -%}	` is used in these 2 files , but its not defined. This will fix the bug.

> https://github.com/rochacbruno/flasgger/blob/master/flasgger/ui2/templates/flasgger/index.html#L78
> 
> https://github.com/rochacbruno/flasgger/blob/master/flasgger/ui3/templates/flasgger/index.html#L106

