### PR TITLE
Avoid inclusion of empty definition dict

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -90,7 +90,7 @@ def convert_schemas(d, definitions=None):
         definitions = {}
     definitions.update(d.get('definitions', {}))
 
-    new = {'definitions': definitions}
+    new = {}
     for k, v in d.items():
         if isinstance(v, dict):
             v = convert_schemas(v, definitions)
@@ -114,5 +114,8 @@ def convert_schemas(d, definitions=None):
                 new[k] = ref
         else:
             new[k] = v
+
+    if len(definitions.keys()) > 0:
+        new['definitions'] = definitions
 
     return new


### PR DESCRIPTION
When using the marshmallow_apispec plugins for flasgger, I discovered that there was an empty definition dictionary in many places it shouldn't be, such as a path parameter. This was causing errors when attempting to validate the generated swagger spec.

This small change should prevent the inclusion of a (potentially) empty definition dictionary at every level of hierarchy, which was causing invalid specs to be generated.