### PR TITLE
Pull schemes from config if present

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -163,6 +163,8 @@ class APISpecsView(MethodView):
             data['host'] = self.config.get('host')
         if self.config.get("basePath"):
             data["basePath"] = self.config.get('basePath')
+        if self.config.get('schemes'):
+            data['schemes'] = self.config.get('schemes')
         if self.config.get("securityDefinitions"):
             data["securityDefinitions"] = self.config.get(
                 'securityDefinitions'


### PR DESCRIPTION
Fixes an issue where `schemes` is respected when provided as template in the constructor 
```python
app.config['SWAGGER'] = { 'uiversion': 3 }
Swagger(app, template={ 'schemes': ['https'] })
```
but not when provided through the config
```python
app.config['SWAGGER'] = {
    'uiversion': 3,
    'schemes': ['https']
}
Swagger(app)
```
Possibly related to #134