### PR TITLE
Update imports to support apispec>=0.39.0

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -7,10 +7,12 @@ import flasgger
 
 try:
     from marshmallow import Schema, fields
-    from apispec.ext.marshmallow.swagger import (
-        schema2jsonschema, schema2parameters
-    )
+    from apispec.ext.marshmallow import openapi
     from apispec import APISpec as BaseAPISpec
+
+    openapi_converter = openapi.OpenAPIConverter(openapi_version='2.0')
+    schema2jsonschema = openapi_converter.schema2jsonschema
+    schema2parameters = openapi_converter.schema2parameters
 except ImportError:
     Schema = None
     fields = None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # optional (for dev)
 marshmallow
-apispec
+apispec>=0.39.0
 flask-restful
 pep8==1.5.7
 flake8==2.4.1


### PR DESCRIPTION
Following the apispec upgrade from 0.38.0 to 0.39.0, its
swagger.py was renamed to openapi.py with support for OpenAPI 3.0.X
as well as OpenAPI 2.0.

In this commit, I only fix the backward-incompatible changed it
introduced without trying to add support for 3.0.X version.

See https://github.com/marshmallow-code/apispec/compare/0.38.0...0.39.0