### PR TITLE
Added install of etc/flasgger_package dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ flask-jwt
 
 # install flasgger itself as editable
 -e .
+-e etc/flasgger_package


### PR DESCRIPTION
Currently if you:

    $ pip install -r requirements.txt -r requirements-dev.txt 

... you cannot run all the examples, specifically:

```
$ python examples/package_example.py 
Traceback (most recent call last):
  File "examples/package_example.py", line 9, in <module>
    from flasgger_package import package_view
ModuleNotFoundError: No module named 'flasgger_package'```

This also prevents `demo_app` from building/deploying (accepting that this is primarily made for the demo site).

This PR just installs `etc/flasgger_package` as local/editable, so that the example can run.  It has to be installed after `flasgger` itself, since the version numbers currently overlap, so making-sure the local dev version is actually installed.  It may have been intentionally omitted, but it is nice to have all examples working, especially since they are auto-imported by `demo_app`.
