### PR TITLE
repaired key error thrown when a path is given instead of in the func…

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -292,6 +292,8 @@ class APISpecsView(MethodView):
                     srule = srule.replace(arg[0], '{%s}' % arg[2])
 
                 for key, val in operations.items():
+                    if srule not in paths:
+                        paths[srule] = {}
                     if key in paths[srule]:
                         paths[srule][key].update(val)
                     else:


### PR DESCRIPTION
There are cases when i want my app to document registered paths that i did not created, as /auth path created by flask_jwt. This fix allows me to create the documentation and register it into swagger via config["paths"] whithout getting a KeyError.