### PR TITLE
Fixed broken image and css links on demo_app landing page

### DIFF
--- a/demo_app/templates/flasgger.html
+++ b/demo_app/templates/flasgger.html
@@ -5,13 +5,13 @@
   <meta http-equiv="x-ua-compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Flasgger - Demo apps</title>
-  <link rel="icon" type="image/png" href="/colors/flasgger_static/images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="/colors/flasgger_static/images/favicon-16x16.png" sizes="16x16" />
-  <link href='/colors/flasgger_static/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='/colors/flasgger_static/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='/colors/flasgger_static/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-  <link href='/colors/flasgger_static/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
-  <link href='/colors/flasgger_static/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+  <link rel="icon" type="image/png" href="/restful/flasgger_static/images/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="/restful/flasgger_static/images/favicon-16x16.png" sizes="16x16" />
+  <link href='/restful/flasgger_static/css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='/restful/flasgger_static/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='/restful/flasgger_static/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='/restful/flasgger_static/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='/restful/flasgger_static/css/print.css' media='print' rel='stylesheet' type='text/css'/>
   <link href='{{ url_for('static', filename='styles.css') }}' rel="styleshet" type='text/css'/>
   <style>
     .swagger-section #header,
@@ -76,20 +76,20 @@
     }
   </style>
 
-  <script src='/colors/flasgger_static/lib/object-assign-pollyfill.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/jquery.slideto.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/jquery.wiggle.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/handlebars-4.0.5.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/lodash.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/backbone-min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/swagger-ui.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/jsoneditor.min.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/marked.js' type='text/javascript'></script>
-  <script src='/colors/flasgger_static/lib/swagger-oauth.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/object-assign-pollyfill.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/lodash.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/swagger-ui.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/marked.js' type='text/javascript'></script>
+  <script src='/restful/flasgger_static/lib/swagger-oauth.js' type='text/javascript'></script>
 
   <!-- Some basic translations -->
   <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
@@ -100,7 +100,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="/colors/apidocs/"><img class="logo__img" alt="swagger" height="30" width="30" src="/colors/flasgger_static/images/logo_small.png" /><span class="logo__title">Flasgger</span></a>
+    <a id="logo" href="/"><img class="logo__img" alt="swagger" height="30" width="30" src="/restful/flasgger_static/images/logo_small.png" /><span class="logo__title">Flasgger</span></a>
   </div>
 </div>
 


### PR DESCRIPTION
Breakage was caused by the use of the /colors example for static files, which has transitioned by-default to uiversion 3.

uiversion 2 is the only static path which contains images and css.  Fixed by switching to /restful, which is currently hard-wired to uiversion 2.

This PR will restore images and CSS to the demo_app landing page.  Currently it generates many 404s.