### PR TITLE
Excluded __pycache__ and *.py[co] from dist. Fixed #137.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,5 @@ recursive-include flasgger/ui3/static/lang *
 recursive-include flasgger/ui3/static/lib *
 recursive-include flasgger/ui3/templates *
 recursive-include flasgger/ui3/templates/flasgger *
+recursive-exclude flasgger __pycache__
+recursive-exclude flasgger *.py[co]


### PR DESCRIPTION
Sanity-check tests I ran:

```
git checkout origin/master

python setup.py sdist bdist_wheel --universal && tar ztf dist/flasgger-0.9.1.dev0.tar.gz > master.flasgger-0.9.1.dev0.tar.gz.list && unzip -l dist/flasgger-0.9.1.dev0-py2.py3-none-any.whl > master.flasgger-0.9.1.dev0-py2.py3-none-any.whl.list

git checkout origin/dist-exclude-pycache

rm -rf build dist

python setup.py sdist bdist_wheel --universal && tar ztf dist/flasgger-0.9.1.dev0.tar.gz > pr.flasgger-0.9.1.dev0.tar.gz.list && unzip -l dist/flasgger-0.9.1.dev0-py2.py3-none-any.whl > pr.flasgger-0.9.1.dev0-py2.py3-none-any.whl.list

diff master.flasgger-0.9.1.dev0.tar.gz.list pr.flasgger-0.9.1.dev0.tar.gz.list 
154,159d153
< flasgger-0.9.1.dev0/flasgger/__pycache__/
< flasgger-0.9.1.dev0/flasgger/__pycache__/constants.cpython-36.pyc
< flasgger-0.9.1.dev0/flasgger/__pycache__/marshmallow_apispec.cpython-36.pyc
< flasgger-0.9.1.dev0/flasgger/__pycache__/base.cpython-36.pyc
< flasgger-0.9.1.dev0/flasgger/__pycache__/utils.cpython-36.pyc
< flasgger-0.9.1.dev0/flasgger/__pycache__/__init__.cpython-36.pyc

diff master.flasgger-0.9.1.dev0-py2.py3-none-any.whl.list pr.flasgger-0.9.1.dev0-py2.py3-none-any.whl.list 
46,50d45
<       699  07-03-2018 09:56   flasgger/__pycache__/__init__.cpython-36.pyc
<     15205  07-03-2018 09:56   flasgger/__pycache__/base.cpython-36.pyc
<       253  07-03-2018 09:56   flasgger/__pycache__/constants.cpython-36.pyc
<      3173  07-03-2018 09:56   flasgger/__pycache__/marshmallow_apispec.cpython-36.pyc
<     21390  07-03-2018 09:56   flasgger/__pycache__/utils.cpython-36.pyc
135,138c130,133
<        27  07-31-2018 10:39   flasgger-0.9.1.dev0.dist-info/top_level.txt
<       110  07-31-2018 10:40   flasgger-0.9.1.dev0.dist-info/WHEEL
<     21149  07-31-2018 10:40   flasgger-0.9.1.dev0.dist-info/METADATA
<     12684  07-31-2018 10:40   flasgger-0.9.1.dev0.dist-info/RECORD
---
>        27  07-31-2018 10:43   flasgger-0.9.1.dev0.dist-info/top_level.txt
>       110  07-31-2018 10:43   flasgger-0.9.1.dev0.dist-info/WHEEL
>     21149  07-31-2018 10:43   flasgger-0.9.1.dev0.dist-info/METADATA
>     12169  07-31-2018 10:43   flasgger-0.9.1.dev0.dist-info/RECORD
140c135
<  15876610                     135 files
---
>  15835375                     130 files
```
Fixed #137.