### PR TITLE
Added a Docker build of the demo_app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6
+
+ADD . /flasgger
+WORKDIR /flasgger
+
+RUN pip3 install -U --no-cache-dir pip && \
+    pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
+    pip3 install --no-cache-dir etc/flasgger_package
+
+EXPOSE 5000
+
+CMD ["python3", "demo_app/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.6
 ADD . /flasgger
 WORKDIR /flasgger
 
-RUN pip3 install -U --no-cache-dir pip && \
-    pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
-    pip3 install --no-cache-dir etc/flasgger_package && \
+RUN pip install -U --no-cache-dir pip && \
+    pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
+    pip install --no-cache-dir etc/flasgger_package && \
     make test && \
     python setup.py sdist bdist_wheel --universal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /flasgger
 
 RUN pip3 install -U --no-cache-dir pip && \
     pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
-    pip3 install --no-cache-dir etc/flasgger_package
+    pip3 install --no-cache-dir etc/flasgger_package && \
+    make test
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /flasgger
 RUN pip3 install -U --no-cache-dir pip && \
     pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
     pip3 install --no-cache-dir etc/flasgger_package && \
-    make test
+    make test && \
+    python setup.py sdist bdist_wheel --universal
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ There are some [example applications](examples/) and you can also play with exam
 
 > NOTE: all the examples apps are also test cases and run automatically in Travis CI to ensure quality and coverage.
 
+## Docker
+
+The examples and demo app can also be built and run as a Docker image/container:
+
+```
+docker build -t flasgger .
+docker run -it --rm -p 5000:5000 --name flasgger flasgger
+```
+Then access the Flasgger demo app at http://localhost:5000 .
+
 # Installation
 
 > under your virtualenv do:


### PR DESCRIPTION
This is mostly a Flasgger developer/contributor focused Docker image build of the demo app.  It allows the current source to be quickly built and run using the demo app as a test-bed.  All (demo app) tests are also run during the image build.

If desired a built sdist and bdist can be pulled from the image on completion, but the main aim is to make it easy to run a container with self-contained Flask running the Flasgger demo app.

Updated README.