### PR TITLE
Added twine to requirements-dev.txt.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ pytest-cov
 decorator
 wheel
 flask-jwt
+twine
 
 # install flasgger itself as editable
 -e .


### PR DESCRIPTION
This is added on the basis that twine is required in order to perform a release.

Learned this running a release for the first time.