### PR TITLE
Add `ui_params_text` similar to existing `header_text`

### DIFF
--- a/examples/changelog_090.py
+++ b/examples/changelog_090.py
@@ -51,7 +51,13 @@ app.config['SWAGGER'] = {
     'ui_params': {
         'apisSorter': 'alpha',
         'operationsSorter': 'alpha',
-    }
+    },
+
+    # Allows overriding any of the uiparams with Javascript expressions
+    # This is useful to override other stuff not provided by the above aliases which cannot be serialized to a JSON string
+    'ui_params_text': '''{
+    "operationsSorter" : (a, b) => a.get("path").localeCompare(b.get("path"))
+}'''
 }
 
 Swagger(app)

--- a/flasgger/ui3/templates/flasgger/swagger.html
+++ b/flasgger/ui3/templates/flasgger/swagger.html
@@ -52,6 +52,9 @@ window.onload = function() {
     
     },
     {{ json.dumps(flasgger_config.get('ui_params', {})) | safe }}
+    {% if flasgger_config.ui_params_text -%}
+    , {{ flasgger_config.ui_params_text | safe }}
+    {%- endif %}
     )
     
     )


### PR DESCRIPTION
We would like to use a custom javascript function for `componentsSorter`. Currently it is impossible to specify it in `ui_params` since it is converted to JSON. Adding a `ui_params_text` similar to the existing `header_text` would allow us to provide such a specification.