### PR TITLE
Added configuration for swagger-ui and jquery js external-load URLs.

### DIFF
--- a/examples/colors_external_js.py
+++ b/examples/colors_external_js.py
@@ -1,0 +1,93 @@
+"""
+The simple example using declared definitions, and external static js/css.
+"""
+
+from flask import Flask, jsonify
+
+from flasgger import Swagger
+
+app = Flask(__name__)
+app.config['SWAGGER'] = {
+    'title': 'Colors API'
+}
+swagger_config = Swagger.DEFAULT_CONFIG
+swagger_config['swagger_ui_bundle_js'] = '//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js'
+swagger_config['swagger_ui_standalone_preset_js'] = '//unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js'
+swagger_config['jquery_js'] = '//unpkg.com/jquery@2.2.4/dist/jquery.min.js'
+swagger_config['swagger_ui_css'] = '//unpkg.com/swagger-ui-dist@3/swagger-ui.css'
+Swagger(app, config=swagger_config)
+
+@app.route('/colors/<palette>/')
+def colors(palette):
+    """Example endpoint return a list of colors by palette
+    This is using docstring for specifications
+    ---
+    tags:
+      - colors
+    parameters:
+      - name: palette
+        in: path
+        type: string
+        enum: ['all', 'rgb', 'cmyk']
+        required: true
+        default: all
+        description: Which palette to filter?
+    operationId: get_colors
+    consumes:
+      - application/json
+    produces:
+      - application/json
+    security:
+      colors_auth:
+        - 'write:colors'
+        - 'read:colors'
+    schemes: ['http', 'https']
+    deprecated: false
+    externalDocs:
+      description: Project repository
+      url: http://github.com/rochacbruno/flasgger
+    definitions:
+      Palette:
+        type: object
+        properties:
+          palette_name:
+            type: array
+            items:
+              $ref: '#/definitions/Color'
+      Color:
+        type: string
+    responses:
+      200:
+        description: A list of colors (may be filtered by palette)
+        schema:
+          $ref: '#/definitions/Palette'
+        examples:
+          rgb: ['red', 'green', 'blue']
+    """
+    all_colors = {
+        'cmyk': ['cian', 'magenta', 'yellow', 'black'],
+        'rgb': ['red', 'green', 'blue']
+    }
+    if palette == 'all':
+        result = all_colors
+    else:
+        result = {palette: all_colors.get(palette)}
+
+    return jsonify(result)
+
+
+def test_swag(client, specs_data):
+    """
+    This test is runs automatically in Travis CI
+
+    :param client: Flask app test client
+    :param specs_data: {'url': {swag_specs}} for every spec in app
+    """
+    for url, spec in specs_data.items():
+        assert 'Palette' in spec['definitions']
+        assert 'Color' in spec['definitions']
+        assert 'colors' in spec['paths']['/colors/{palette}/']['get']['tags']
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -87,6 +87,23 @@ class APIDocsView(MethodView):
                 'favicon',
                 url_for('flasgger.static', filename='favicon-32x32.png')
             )
+            data['swagger_ui_bundle_js'] = self.config.get(
+                'swagger_ui_bundle_js',
+                url_for('flasgger.static', filename='swagger-ui-bundle.js')
+            )
+            data['swagger_ui_standalone_preset_js'] = self.config.get(
+                'swagger_ui_standalone_preset_js',
+                url_for('flasgger.static',
+                        filename='swagger-ui-standalone-preset.js')
+            )
+            data['jquery_js'] = self.config.get(
+                'jquery_js',
+                url_for('flasgger.static', filename='lib/jquery.min.js')
+            )
+            data['swagger_ui_css'] = self.config.get(
+                'swagger_ui_css',
+                url_for('flasgger.static', filename='swagger-ui.css')
+            )
             return render_template(
                 'flasgger/index.html',
                 **data

--- a/flasgger/ui3/templates/flasgger/body_scripts.html
+++ b/flasgger/ui3/templates/flasgger/body_scripts.html
@@ -1,0 +1,3 @@
+<script src="{{ swagger_ui_bundle_js }}"></script>
+<script src="{{ swagger_ui_standalone_preset_js }}"></script>
+<script src="{{ jquery_js }}" type='text/javascript'></script>

--- a/flasgger/ui3/templates/flasgger/head.html
+++ b/flasgger/ui3/templates/flasgger/head.html
@@ -1,7 +1,7 @@
 <meta charset="UTF-8">
 <title>{{ title }}</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-<link rel="stylesheet" type="text/css" href="{{url_for('flasgger.static', filename='swagger-ui.css')}}" >
+<link rel="stylesheet" type="text/css" href="{{ swagger_ui_css }}">
 <!-- Customize the app.config['SWAGGER']['favicon'] -->
 <link rel="icon" type="image/png" href="{{ favicon }}" sizes="64x64 32x32 16x16" />
 <style>

--- a/flasgger/ui3/templates/flasgger/index.html
+++ b/flasgger/ui3/templates/flasgger/index.html
@@ -22,13 +22,11 @@
           </div>
           </div>
       </div>
-    
+
     <div id="swagger-ui"></div>
 
-    <script src="{{url_for('flasgger.static', filename='swagger-ui-bundle.js')}}"> </script>
-    <script src="{{url_for('flasgger.static', filename='swagger-ui-standalone-preset.js')}}"> </script>
-    <script src="{{url_for('flasgger.static', filename='lib/jquery.min.js')}}" type='text/javascript'></script>
-    
+    {% include 'flasgger/body_scripts.html' %}
+
   <!-- To customize the script that loads swagger, override templates/flasgger/swagger.html -->
   {% include 'flasgger/swagger.html' %}
 


### PR DESCRIPTION
This change allows new Flasgger config keys to specify the URL location where Swagger UI and jQuery javascript sources are loaded from, allowing them to be loaded from Flasgger's static copies (default), or any URL, including hosted sources.  This can allow any compatible version of those libraries to be loaded, allowing the latest Swagger UI to be loaded by Flasgger templates.

The new, optional config keys are:

- swagger_ui_bundle_js
- swagger_ui_standalone_preset_js
- jquery_js

For example, the following can be used to load scripts from unpkg.com:

```
app = Flask(__name__)
app.config['SWAGGER'] = {
    'title': 'Colors API'
}
swagger_config = Swagger.DEFAULT_CONFIG
swagger_config['swagger_ui_bundle_js'] = '//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js'
swagger_config['swagger_ui_standalone_preset_js'] = '//unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js'
swagger_config['jquery_js'] = '//unpkg.com/jquery@2.2.4/dist/jquery.min.js'
Swagger(app, config=swagger_config)
```

As part of this change, template part flasgger/body_scripts.html was factored-out of index.html, making it easier to override and replace the body script load section entirely if desired.

Added a test/example.

This is somewhat inspired by discussions in #231, so I mention it here.

## Questions

- Is the _colors_ example a good base for new test/example code?  That's what I copied for the test/example.  I wonder if we should have a canonical, minimal, template example app that forms the base for tests which need to exercise one function without testing unwanted features or copying a lot of example code.
- I exposed three new config keys.  I was wondering if there was a more generic way of doing this, or allowing override, other than the addition of the factored-out `body_scripts.html` template.
- Check config key names - I didn't include `url` in them.

## Testing

- Access the new `colors_external_js` example with a browser in developer mode and note where the scripts are fetched from.  The example is using a floating/latest ui3 mechanism, so there is a redirect involved.  This loads the latest Swagger UI 3.x, which currently loads 3.19.0.

## TODO

- ~~I notice I need to externalise the CSS link too.~~