### PR TITLE
Attempt to fix markdown readme on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 before_install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - python setup.py check --strict
 
 script:
   - make test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,11 @@ pytest-cov
 decorator
 wheel
 flask-jwt
-twine
+twine>=1.11.0
+
+# for pypi markdown support
+readme_renderer
+setuptools>=40.4.2
 
 # install flasgger itself as editable
 -e .

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,7 @@
 import re
 import os
 
-try:
-    from setuptools import setup, find_packages
-except ImportError:
-    from distutils.core import setup, find_packages
+from setuptools import setup, find_packages
 
 
 def fpath(name):
@@ -43,8 +40,8 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(
         exclude=[
-            'tests', 'tests.*', 
-            'examples', 'examples.*', 
+            'tests', 'tests.*',
+            'examples', 'examples.*',
             'demo_app', 'demo_app.*',
             'etc', 'etc.*'
         ]


### PR DESCRIPTION
On Pypi markdown readme is not being rendered.

Markdown readme renderer seens to require setuptools>=40
also add readme_renderer ro --check locally

https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi