### PR TITLE
Added Python 3.7 and 3.8-dev to tox and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: python
 
-python:
-  - 2.7
-  - 3.6
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
+    - python: 3.8-dev
+      env: TOXENV=py38-dev
+      dist: xenial
+      sudo: true
+  allow_failures:
+    - env: TOXENV=py38-dev
 
 before_install:
   - pip install -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py36
+envlist = py28, py36, py37, py38-dev
 
 [testenv]
 whitelist_externals = make


### PR DESCRIPTION
This builds Flasgger in 3.7 and 3.8-dev (failures allowed) in Travis, retaining the existing environments.  It also adds the `tox` environments for running with `tox`.  I set `TOXENV` in Travis although this is not strictly necessary since Travis is not using Tox currently.

Note that this requires a switch to a build matrix with some added complexity, since different dists are currently required in Travis to get Python 3.7 and 3.8-dev images.