### PR TITLE
Compatibility with apispec 1.0.0b5

### DIFF
--- a/examples/apispec_example.py
+++ b/examples/apispec_example.py
@@ -5,14 +5,17 @@ Example using marshmallow APISpec as base template for Flasgger specs
 from flask import Flask, jsonify
 
 from flasgger import APISpec, Schema, Swagger, fields
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
 
 # Create an APISpec
 spec = APISpec(
     title='Flasger Petstore',
     version='1.0.10',
+    openapi_version='2.0',
     plugins=[
-        'apispec.ext.flask',
-        'apispec.ext.marshmallow',
+        FlaskPlugin(),
+        MarshmallowPlugin(),
     ],
 )
 

--- a/examples/apispec_example_uiversion3.py
+++ b/examples/apispec_example_uiversion3.py
@@ -6,14 +6,17 @@ and using the Swagger UI new style layout version 3
 from flask import Flask, jsonify
 
 from flasgger import APISpec, Schema, Swagger, fields
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
 
 # Create an APISpec
 spec = APISpec(
     title='Flasger Petstore',
     version='1.0.10',
+    openapi_version='2.0',
     plugins=[
-        'apispec.ext.flask',
-        'apispec.ext.marshmallow',
+        FlaskPlugin(),
+        MarshmallowPlugin(),
     ],
 )
 

--- a/flasgger/utils.py
+++ b/flasgger/utils.py
@@ -388,10 +388,10 @@ def apispec_to_template(app, spec, definitions=None, paths=None):
                 schema = definition
                 name = schema.__name__.replace('Schema', '')
 
-            spec.definition(name, schema=schema)
+            spec.components.schema(name, schema=schema)
 
         for path in paths:
-            spec.add_path(view=path)
+            spec.path(view=path)
 
     ret = ordered_dict_to_dict(spec_dict)
     return ret

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # optional (for dev)
 marshmallow
-apispec>=0.39.0
+apispec>=1.0.0b5
 flask-restful
 pep8==1.5.7
 flake8==2.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # optional (for dev)
 marshmallow
 apispec>=1.0.0b5
+apispec-webframeworks
 flask-restful
 pep8==1.5.7
 flake8==2.4.1


### PR DESCRIPTION
definition and add_path renamed in `apispec==1.0.0b5`:  
https://github.com/marshmallow-code/apispec/blob/dev/CHANGELOG.rst#100b5-2018-11-06