### PR TITLE
Add safe getter with empty return if attrib does not exist

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -569,7 +569,7 @@ class Swagger(object):
                 schemas = defaultdict(
                     lambda: {'type': 'object', 'properties': defaultdict(dict)}
                 )
-                for param in doc['parameters']:
+                for param in doc.get('parameters', []):
                     location = self.SCHEMA_LOCATIONS[param['in']]
                     if location == 'json':
                         schemas[location]['properties'].update(


### PR DESCRIPTION
This fixes an issue where operations fail if there is no parameters or empty parameters section defined in the spec.