### PR TITLE
Bugfix: can't dict.update([dict])

### DIFF
--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -351,7 +351,10 @@ class Swagger(object):
         for rule, verbs in specs:
             operations = dict()
             for verb, swag in verbs:
-                definitions.update(swag.get('definitions', {}))
+                update_dict = swag.get('definitions', {})
+                if type(update_dict) == list and type(update_dict[0]) == dict:
+                        update_dict, = update_dict  # pop, assert single element
+                definitions.update(update_dict)
                 defs = []  # swag.get('definitions', [])
                 defs += extract_definitions(
                     defs, endpoint=rule.endpoint, verb=verb,

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -43,9 +43,17 @@ from .utils import validate
 from .utils import LazyString
 from . import __version__
 
-NO_SANITIZER = lambda text: text  # noqa
-BR_SANITIZER = lambda text: text.replace('\n', '<br/>') if text else text  # noqa
-MK_SANITIZER = lambda text: Markup(markdown(text)) if text else text  # noqa
+
+def NO_SANITIZER(text):
+    return text
+
+
+def BR_SANITIZER(text):
+    return text.replace('\n', '<br/>') if text else text
+
+
+def MK_SANITIZER(text):
+    return Markup(markdown(text)) if text else text
 
 
 class APIDocsView(MethodView):

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -353,7 +353,8 @@ class Swagger(object):
             for verb, swag in verbs:
                 update_dict = swag.get('definitions', {})
                 if type(update_dict) == list and type(update_dict[0]) == dict:
-                        update_dict, = update_dict  # pop, assert single element
+                        # pop, assert single element
+                        update_dict, = update_dict
                 definitions.update(update_dict)
                 defs = []  # swag.get('definitions', [])
                 defs += extract_definitions(

--- a/flasgger/base.py
+++ b/flasgger/base.py
@@ -353,8 +353,8 @@ class Swagger(object):
             for verb, swag in verbs:
                 update_dict = swag.get('definitions', {})
                 if type(update_dict) == list and type(update_dict[0]) == dict:
-                        # pop, assert single element
-                        update_dict, = update_dict
+                    # pop, assert single element
+                    update_dict, = update_dict
                 definitions.update(update_dict)
                 defs = []  # swag.get('definitions', [])
                 defs += extract_definitions(


### PR DESCRIPTION
I've no idea why I'm hitting this bug, but this commit works around it and shouldn't negatively effect anything else.