### PR TITLE
Restricting jsonschema library to be in between 2.5.1 and less than 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Flask>=0.10',
         'PyYAML>=3.0',
         'jsonschema>=2.5.1',
+        'jsonschema<3.0.0',
         'mistune',
         'six>=1.10.0'
     ]


### PR DESCRIPTION
```  File "/usr/local/lib/python3.6/site-packages/flasgger/__init__.py", line 7, in <module>
    from jsonschema import ValidationError  # noqa
  File "/usr/local/lib/python3.6/site-packages/jsonschema/__init__.py", line 22, in <module>
    from jsonschema._types import TypeChecker
  File "/usr/local/lib/python3.6/site-packages/jsonschema/_types.py", line 49, in <module>
    class TypeChecker(object):
  File "/usr/local/lib/python3.6/site-packages/jsonschema/_types.py", line 64, in TypeChecker
    _type_checkers = attr.ib(default=pmap(), converter=pmap)
TypeError: attr() got an unexpected keyword argument 'converter'```