### PR TITLE
Pass default resolver to OpenAPIConverter

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -7,12 +7,12 @@ import flasgger
 
 try:
     from marshmallow import Schema, fields
-    from apispec.ext.marshmallow import openapi
+    from apispec.ext.marshmallow import openapi, resolver
     from apispec import APISpec as BaseAPISpec
 
     openapi_converter = openapi.OpenAPIConverter(
         openapi_version='2.0',
-        schema_name_resolver=None,
+        schema_name_resolver=resolver,
         spec=None
     )
     schema2jsonschema = openapi_converter.schema2jsonschema


### PR DESCRIPTION
Fix for https://github.com/rochacbruno/flasgger/issues/285

Use `apispec.ext.marshmallow.resolver` instead of `None` to init `apispec.ext.marshmallow.openapi.OpenAPIConverter`