### PR TITLE
Fix for tests

### DIFF
--- a/flasgger/marshmallow_apispec.py
+++ b/flasgger/marshmallow_apispec.py
@@ -12,7 +12,7 @@ try:
 
     openapi_converter = openapi.OpenAPIConverter(
         openapi_version='2.0',
-        schema_name_resolver=None,
+        schema_name_resolver=lambda schema: None,
         spec=None
     )
     schema2jsonschema = openapi_converter.schema2jsonschema


### PR DESCRIPTION
Currently tests are broken.

```bash
(venv) ~/projects/flasgger$ git status
On branch master
Your branch is up to date with 'origin/master'.
 
nothing to commit, working tree clean
(venv) ~/projects/flasgger$ make test
...
make: *** [test] Error 2
```
https://pastebin.com/puUDPZqH

This PR fixes the problem.

Change summary: pass `schema_name_resolver=lambda schema: None` instead of `schema_name_resolver=None` to `OpenAPIConverter` constructor

See also: https://github.com/rochacbruno/flasgger/issues/285